### PR TITLE
Misc/qxo integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.dylib
 bin
 
+# Folder in which make test download envtest
+testbin/
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@ domain: kubestatic.quortex.io
 layout:
 - go.kubebuilder.io/v3
 projectName: kubestatic
-repo: quortex.io/kubestatic
+repo: github.com/quortex/kubestatic
 resources:
 - api:
     crdVersion: v1
@@ -10,7 +10,7 @@ resources:
   controller: true
   domain: kubestatic.quortex.io
   kind: ExternalIP
-  path: quortex.io/kubestatic/api/v1alpha1
+  path: github.com/quortex/kubestatic/api/v1alpha1
   version: v1alpha1
 - controller: true
   domain: kubestatic.quortex.io
@@ -22,6 +22,6 @@ resources:
   controller: true
   domain: kubestatic.quortex.io
   kind: FirewallRule
-  path: quortex.io/kubestatic/api/v1alpha1
+  path: github.com/quortex/kubestatic/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/controllers/externalip_controller.go
+++ b/controllers/externalip_controller.go
@@ -32,9 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/helper"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/helper"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 const (

--- a/controllers/externalip_controller_test.go
+++ b/controllers/externalip_controller_test.go
@@ -25,11 +25,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/provider"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/provider"
 )
 
 var _ = Describe("ExternalIP Controller", func() {

--- a/controllers/firewallrule_controller.go
+++ b/controllers/firewallrule_controller.go
@@ -31,9 +31,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/helper"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/helper"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 const (

--- a/controllers/firewallrule_controller_test.go
+++ b/controllers/firewallrule_controller_test.go
@@ -29,14 +29,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/helper"
+	"github.com/quortex/kubestatic/pkg/provider"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/helper"
-	"quortex.io/kubestatic/pkg/provider"
 )
 
 var _ = Describe("FirewallRule Controller", func() {

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -34,8 +36,10 @@ import (
 )
 
 const (
-	// externalIPAutoAssignLabel is the key for auto externalIP assignement label
+	// externalIPAutoAssignLabel is the key for auto externalIP assignment label
 	externalIPAutoAssignLabel = "kubestatic.quortex.io/externalip-auto-assign"
+	// externalIPLabel is the key for auto externalIP label (the externalIP a pod should have)
+	externalIPLabel = "kubestatic.quortex.io/externalip"
 	// externalIPNodeNameField is the nodeName field in ExternalIP resource
 	externalIPNodeNameField = ".spec.nodeName"
 )
@@ -89,10 +93,27 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err
 	}
 
-	// Some orphaned auto assigned ExternalIPs, reuse one arbitrarly
+	// Some orphaned auto assigned ExternalIPs, check which one to reuse
 	if len(externalIPs.Items) > 0 {
-		// We reuse the first one arbitrarly
-		externalIP := &externalIPs.Items[0]
+		// List pods that should be scheduled on orphaned ExternalIPs
+		publicIPAddresses := publicIPAddresses(externalIPs.Items)
+		lblValue := fmt.Sprintf("in (%s)", strings.Join(publicIPAddresses, ","))
+		log.V(1).Info("List all Pods with labels", "key", externalIPLabel, "value", lblValue)
+		podList := &corev1.PodList{}
+		if err := r.Client.List(
+			ctx,
+			podList,
+			client.MatchingLabels{externalIPAutoAssignLabel: lblValue},
+		); err != nil {
+			log.Error(err, "List all Pods with labels", "key", externalIPLabel, "value", lblValue)
+			return ctrl.Result{}, err
+		}
+
+		// We get the most referenced ExternalIP ore reuse the first one arbitrarily
+		externalIP := getMostReferencedIP(podList.Items, externalIPs.Items)
+		if externalIP == nil {
+			externalIP = &externalIPs.Items[0]
+		}
 		externalIP.Spec.NodeName = req.Name
 		log.V(1).Info("Associating ExternalIP to node", "externalIP", externalIP.Name)
 		return ctrl.Result{}, r.Update(ctx, externalIP)

--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -23,11 +23,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/helper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/helper"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/controllers/node_controller_test.go
+++ b/controllers/node_controller_test.go
@@ -25,10 +25,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/provider"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/provider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -42,9 +42,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/provider"
-	"quortex.io/kubestatic/pkg/provider/aws"
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider/aws"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"quortex.io/kubestatic/api/v1alpha1"
+)
+
+// publicIPAddresses returns public IP addresses of the given ExternalIPs
+func publicIPAddresses(eips []v1alpha1.ExternalIP) (res []string) {
+	for _, e := range eips {
+		if e.Status.PublicIPAddress != nil {
+			res = append(res, *e.Status.PublicIPAddress)
+		}
+	}
+	return
+}
+
+// countReferencedIP counts pods that refer to the kubestatic.quortex.io/externalip label with the desired ip
+func countReferencedIP(pods []corev1.Pod, ip string) (count int) {
+	for _, e := range pods {
+		if e.Labels[externalIPLabel] == ip {
+			count++
+		}
+	}
+	return
+}
+
+// getMostReferencedIP returns the IP that is the most referenced by the kubestatic.quortex.io/externalip label
+func getMostReferencedIP(pods []corev1.Pod, eips []v1alpha1.ExternalIP) (ip *v1alpha1.ExternalIP) {
+	count := 0
+	for i, e := range eips {
+		if c := countReferencedIP(pods, *e.Status.PublicIPAddress); c > count {
+			count = c
+			ip = &eips[i]
+		}
+	}
+	return
+}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -17,8 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"github.com/quortex/kubestatic/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"quortex.io/kubestatic/api/v1alpha1"
 )
 
 // publicIPAddresses returns public IP addresses of the given ExternalIPs

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"quortex.io/kubestatic/api/v1alpha1"
+	"quortex.io/kubestatic/pkg/helper"
+)
+
+func Test_publicIPAddresses(t *testing.T) {
+	type args struct {
+		eips []v1alpha1.ExternalIP
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantRes []string
+	}{
+		{
+			name: "empty ExternalIPs should return empty public IP addresses",
+			args: args{
+				eips: nil,
+			},
+			wantRes: nil,
+		},
+		{
+			name: "ExternalIPs with empty PublicIPAddress should return empty public IP addresses",
+			args: args{
+				eips: []v1alpha1.ExternalIP{
+					{
+						Status: v1alpha1.ExternalIPStatus{
+							PublicIPAddress: nil,
+						},
+					},
+				},
+			},
+			wantRes: nil,
+		},
+		{
+			name: "ExternalIPs with empty PublicIPAddress should return empty public IP addresses",
+			args: args{
+				eips: []v1alpha1.ExternalIP{
+					{
+						Status: v1alpha1.ExternalIPStatus{
+							PublicIPAddress: helper.StringPointer("foo"),
+						},
+					},
+					{
+						Status: v1alpha1.ExternalIPStatus{
+							PublicIPAddress: helper.StringPointer("bar"),
+						},
+					},
+				},
+			},
+			wantRes: []string{
+				"foo",
+				"bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotRes := publicIPAddresses(tt.args.eips); !reflect.DeepEqual(gotRes, tt.wantRes) {
+				t.Errorf("publicIPAddresses() = %v, want %v", gotRes, tt.wantRes)
+			}
+		})
+	}
+}
+
+func Test_countReferencedIP(t *testing.T) {
+	type args struct {
+		pods []corev1.Pod
+		ip   string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantCount int
+	}{
+		{
+			name: "empty pods should return zero",
+			args: args{
+				pods: nil,
+				ip:   "foo",
+			},
+			wantCount: 0,
+		},
+		{
+			name: "count referenced IP should work properly",
+			args: args{
+				pods: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "foo",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "foo",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "bar",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "foo",
+							},
+						},
+					},
+				},
+				ip: "foo",
+			},
+			wantCount: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotCount := countReferencedIP(tt.args.pods, tt.args.ip); gotCount != tt.wantCount {
+				t.Errorf("countReferencedIP() = %v, want %v", gotCount, tt.wantCount)
+			}
+		})
+	}
+}
+
+func Test_getMostReferencedIP(t *testing.T) {
+	type args struct {
+		pods []corev1.Pod
+		eips []v1alpha1.ExternalIP
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v1alpha1.ExternalIP
+	}{
+		{
+			name: "empty pods / empty ips should return nil",
+			args: args{
+				pods: nil,
+				eips: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "get most referenced ip should work properly",
+			args: args{
+				pods: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "foo",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "foo",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "bar",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								externalIPLabel: "foo",
+							},
+						},
+					},
+				},
+				eips: []v1alpha1.ExternalIP{
+					{
+						Status: v1alpha1.ExternalIPStatus{
+							PublicIPAddress: helper.StringPointer("foo"),
+						},
+					},
+					{
+						Status: v1alpha1.ExternalIPStatus{
+							PublicIPAddress: helper.StringPointer("bar"),
+						},
+					},
+				},
+			},
+			want: &v1alpha1.ExternalIP{
+				Status: v1alpha1.ExternalIPStatus{
+					PublicIPAddress: helper.StringPointer("foo"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getMostReferencedIP(tt.args.pods, tt.args.eips); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getMostReferencedIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -20,10 +20,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/pkg/helper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/pkg/helper"
 )
 
 func Test_publicIPAddresses(t *testing.T) {

--- a/docs/api-docs.asciidoc
+++ b/docs/api-docs.asciidoc
@@ -7,8 +7,8 @@
 
 .Packages
 * xref:{anchor_prefix}-kubestatic-quortex-io-v1alpha1[$$kubestatic.quortex.io/v1alpha1$$]
-** xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-externalip[$$ExternalIP$$]
-** xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-firewallrule[$$FirewallRule$$]
+** xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-externalip[$$ExternalIP$$]
+** xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-firewallrule[$$FirewallRule$$]
 
 
 
@@ -18,12 +18,12 @@
 Package v1alpha1 contains API Schema definitions for the  v1alpha1 API group
 
 .Resource Types
-- xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-externalip[$$ExternalIP$$]
-- xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-firewallrule[$$FirewallRule$$]
+- xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-externalip[$$ExternalIP$$]
+- xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-firewallrule[$$FirewallRule$$]
 
 
 
-[id="{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-externalip"]
+[id="{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-externalip"]
 === ExternalIP
 
 ExternalIP is the Schema for the externalips API
@@ -37,18 +37,18 @@ ExternalIP is the Schema for the externalips API
 | *`kind`* __string__ | `ExternalIP`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-externalipspec[$$ExternalIPSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-externalipspec[$$ExternalIPSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-externalipspec"]
+[id="{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-externalipspec"]
 === ExternalIPSpec
 
 ExternalIPSpec defines the desired state of ExternalIP
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-externalip[$$ExternalIP$$]
+- xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-externalip[$$ExternalIP$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -58,7 +58,7 @@ ExternalIPSpec defines the desired state of ExternalIP
 |===
 
 
-[id="{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-firewallrule"]
+[id="{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-firewallrule"]
 === FirewallRule
 
 FirewallRule is the Schema for the firewallrules API
@@ -72,18 +72,18 @@ FirewallRule is the Schema for the firewallrules API
 | *`kind`* __string__ | `FirewallRule`
 | *`metadata`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta[$$ObjectMeta$$]__ | Refer to Kubernetes API documentation for fields of `metadata`.
 
-| *`spec`* __xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-firewallrulespec[$$FirewallRuleSpec$$]__ | 
+| *`spec`* __xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-firewallrulespec[$$FirewallRuleSpec$$]__ | 
 |===
 
 
-[id="{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-firewallrulespec"]
+[id="{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-firewallrulespec"]
 === FirewallRuleSpec
 
 FirewallRuleSpec defines the desired state of FirewallRule
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-firewallrule[$$FirewallRule$$]
+- xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-firewallrule[$$FirewallRule$$]
 ****
 
 [cols="25a,75a", options="header"]
@@ -94,19 +94,19 @@ FirewallRuleSpec defines the desired state of FirewallRule
 | *`direction`* __Direction__ | The traffic direction. Ingress applies to incoming traffic. Egress applies to outbound traffic.
 | *`fromPort`* __integer__ | The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number.
 | *`protocol`* __string__ | The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)). Use -1 to specify all protocols.
-| *`ipRanges`* __xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-iprange[$$IPRange$$]__ | The IPv4 ranges.
+| *`ipRanges`* __xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-iprange[$$IPRange$$]__ | The IPv4 ranges.
 | *`toPort`* __integer__ | The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code.
 |===
 
 
-[id="{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-iprange"]
+[id="{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-iprange"]
 === IPRange
 
 IPRange Describes an IPv4 range.
 
 .Appears In:
 ****
-- xref:{anchor_prefix}-quortex-io-kubestatic-api-v1alpha1-firewallrulespec[$$FirewallRuleSpec$$]
+- xref:{anchor_prefix}-github-com-quortex-kubestatic-api-v1alpha1-firewallrulespec[$$FirewallRuleSpec$$]
 ****
 
 [cols="25a,75a", options="header"]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module quortex.io/kubestatic
+module github.com/quortex/kubestatic
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -33,10 +33,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	kubestaticquortexiov1alpha1 "quortex.io/kubestatic/api/v1alpha1"
-	"quortex.io/kubestatic/controllers"
-	"quortex.io/kubestatic/pkg/provider"
-	"quortex.io/kubestatic/pkg/provider/aws"
+	kubestaticquortexiov1alpha1 "github.com/quortex/kubestatic/api/v1alpha1"
+	"github.com/quortex/kubestatic/controllers"
+	"github.com/quortex/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider/aws"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -6,6 +6,11 @@ func StringPointerOrNil(s string) *string {
 	if s == "" {
 		return nil
 	}
+	return StringPointer(s)
+}
+
+// StringPointer converts a string value to a string pointer.
+func StringPointer(s string) *string {
 	return &s
 }
 

--- a/pkg/provider/aws/converter/address_decoder.go
+++ b/pkg/provider/aws/converter/address_decoder.go
@@ -4,7 +4,7 @@ package converter
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 // DecodeAddress converts an ec2 Address to an Address.

--- a/pkg/provider/aws/converter/address_decoder_test.go
+++ b/pkg/provider/aws/converter/address_decoder_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 func TestDecodeAddress(t *testing.T) {

--- a/pkg/provider/aws/converter/error_decoder.go
+++ b/pkg/provider/aws/converter/error_decoder.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 // DecodeEC2Error converts an ec2 specific Error to a QXError.

--- a/pkg/provider/aws/converter/instance_decoder.go
+++ b/pkg/provider/aws/converter/instance_decoder.go
@@ -4,7 +4,7 @@ package converter
 import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 // DecodeInstance converts an ec2 Instance to an Instance.

--- a/pkg/provider/aws/converter/instance_decoder_test.go
+++ b/pkg/provider/aws/converter/instance_decoder_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 func TestDecodeInstance(t *testing.T) {

--- a/pkg/provider/aws/converter/security_group_decoder.go
+++ b/pkg/provider/aws/converter/security_group_decoder.go
@@ -5,7 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 // DecodeSecurityGroup converts an ec2 SecurityGroup to a Firewall.

--- a/pkg/provider/aws/converter/security_group_decoder_test.go
+++ b/pkg/provider/aws/converter/security_group_decoder_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 func TestDecodeSecurityGroups(t *testing.T) {

--- a/pkg/provider/aws/converter/security_group_encoder.go
+++ b/pkg/provider/aws/converter/security_group_encoder.go
@@ -5,8 +5,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
-	"quortex.io/kubestatic/pkg/helper"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/helper"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 // EncodeIPPermission converts an IPPermission to an ec2 IpPermission.

--- a/pkg/provider/aws/converter/security_group_encoder_test.go
+++ b/pkg/provider/aws/converter/security_group_encoder_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"quortex.io/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider"
 )
 
 func TestEncodeIPPermission(t *testing.T) {

--- a/pkg/provider/aws/provider.go
+++ b/pkg/provider/aws/provider.go
@@ -13,8 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	corev1 "k8s.io/api/core/v1"
 
-	"quortex.io/kubestatic/pkg/provider"
-	"quortex.io/kubestatic/pkg/provider/aws/converter"
+	"github.com/quortex/kubestatic/pkg/provider"
+	"github.com/quortex/kubestatic/pkg/provider/aws/converter"
 )
 
 const (
@@ -26,7 +26,7 @@ const (
 // The VPC identifier
 // Automatically retrieved with GetVPCID function.
 // For run outside of the cluster, can be set through linker flag, e.g.
-// go build -ldflags "-X quortex.io/kubestatic/pkg/provider/aws.vpcID=$VPC_ID" -a -o manager main.go
+// go build -ldflags "-X github.com/quortex/kubestatic/pkg/provider/aws.vpcID=$VPC_ID" -a -o manager main.go
 var vpcID string
 
 type awsProvider struct {

--- a/pkg/provider/utils_test.go
+++ b/pkg/provider/utils_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"quortex.io/kubestatic/pkg/helper"
+	"github.com/quortex/kubestatic/pkg/helper"
 )
 
 func Test_computePermissionRequests(t *testing.T) {


### PR DESCRIPTION
Required to switch QxO to kubestatic
Changes :
* Change project go module to `github.com/quortex/kubestatic`
* Set orphaned ExternalIP reuse priority based on a reserved pod label