### PR TITLE
Fix bug : SecurityGroup was associated to the wrong NetworkInterface

### DIFF
--- a/controllers/externalip_controller.go
+++ b/controllers/externalip_controller.go
@@ -258,7 +258,7 @@ func (r *ExternalIPReconciler) reconcileExternalIPDeletion(ctx context.Context, 
 	// Release unassociated address.
 	if externalIP.IsReserved() {
 		if err := r.Provider.DeleteAddress(ctx, *externalIP.Status.AddressID); err != nil {
-			if !errors.IsNotFound(err) {
+			if !provider.IsErrNotFound(err) {
 				log.Error(err, "Failed to delete Address", "addressID", *externalIP.Status.AddressID)
 				return ctrl.Result{}, err
 			}

--- a/controllers/firewallrule_controller.go
+++ b/controllers/firewallrule_controller.go
@@ -268,7 +268,7 @@ func (r *FirewallRuleReconciler) reconcileFirewallRuleDeletion(ctx context.Conte
 	// Release unassociated firewall rule.
 	if rule.IsReserved() {
 		if err := r.Provider.DeleteFirewallRule(ctx, *rule.Status.FirewallRuleID); err != nil {
-			if !errors.IsNotFound(err) {
+			if !provider.IsErrNotFound(err) {
 				log.Error(err, "Failed to delete FirewallRule", "firewallRuleID", *rule.Status.FirewallRuleID)
 				return ctrl.Result{}, err
 			}


### PR DESCRIPTION
The SG was associated to the first NI found, and nodes have two NI (one internal and one public).
This was not working all the time since the order is not consistent between the two.
Now we associate the SG to the first NI with a PublicIP found, which should work while we have one PublicIP per node.

Also fixed a bug wher "NotFound" errors where not ignored during deletion.