### PR TITLE
Disassociate & delete rule when the instanceID do not match nodeName

### DIFF
--- a/api/v1alpha1/firewallrule_types.go
+++ b/api/v1alpha1/firewallrule_types.go
@@ -93,7 +93,7 @@ type FirewallRuleStatus struct {
 	// The latest FirewallRule specification applied, used to make API requests to cloud providers only if the resource has been changed to avoid throttling issues.
 	LastApplied *string `json:"lastApplied,omitempty"`
 
-	// The firewall rule dientifier
+	// The firewall rule identifier
 	FirewallRuleID *string `json:"firewallRuleID,omitempty"`
 
 	// The instance identifier

--- a/config/crd/bases/kubestatic.quortex.io_firewallrules.yaml
+++ b/config/crd/bases/kubestatic.quortex.io_firewallrules.yaml
@@ -109,7 +109,7 @@ spec:
             description: FirewallRuleStatus defines the observed state of FirewallRule
             properties:
               firewallRuleID:
-                description: The firewall rule dientifier
+                description: The firewall rule identifier
                 type: string
               instanceID:
                 description: The instance identifier

--- a/controllers/firewallrule_controller.go
+++ b/controllers/firewallrule_controller.go
@@ -284,7 +284,7 @@ func (r *FirewallRuleReconciler) reconcileFirewallRule(ctx context.Context, log 
 					// Set status back to Reserved
 					rule.Status.State = v1alpha1.FirewallRuleStateReserved
 					log.V(1).Info("Updating FirewallRule", "state", rule.Status.State, "InstanceID", rule.Status.InstanceID)
-					if err != r.Status().Update(ctx, rule) {
+					if err = r.Status().Update(ctx, rule); err != nil {
 						log.Error(err, "Failed to update FirewallRule status", "firewallRule", rule.Name, "status", rule.Status.State)
 						return ctrl.Result{}, err
 					}

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -48,6 +48,11 @@ func countReferencedIP(pods []corev1.Pod, ip string) (count int) {
 func getMostReferencedIP(pods []corev1.Pod, eips []v1alpha1.ExternalIP) (ip *v1alpha1.ExternalIP) {
 	count := 0
 	for i, e := range eips {
+		// Skip externalIP without PublicIPAddress
+		if e.Status.PublicIPAddress == nil {
+			continue
+		}
+
 		if c := countReferencedIP(pods, *e.Status.PublicIPAddress); c > count {
 			count = c
 			ip = &eips[i]
@@ -59,7 +64,7 @@ func getMostReferencedIP(pods []corev1.Pod, eips []v1alpha1.ExternalIP) (ip *v1a
 const charset = "abcdefghijklmnopqrstuvwxyz"
 
 func randomString(length int) string {
-	var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	b := make([]byte, length)
 	for i := range b {
 		b[i] = charset[seededRand.Intn(len(charset))]

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.0
+	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
@@ -79,7 +80,6 @@ require (
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
This is useful to allow node names to be changed by a user or another operator.

* Fix typo in API documentation
* Do not remove nodeName when clearing the rule from provider.
