### PR TITLE
Add a delay between two reconciliation for external IPs & Firewall Rules

### DIFF
--- a/controllers/externalip_controller.go
+++ b/controllers/externalip_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -119,7 +120,7 @@ func (r *ExternalIPReconciler) reconcileExternalIP(ctx context.Context, log logr
 		externalIP.Status.AddressID = &res.AddressID
 		externalIP.Status.PublicIPAddress = &res.PublicIP
 		log.V(1).Info("Updating ExternalIP", "state", externalIP.Status.State, "addressID", externalIP.Status.AddressID, "PublicIPAddress", externalIP.Status.PublicIPAddress)
-		return ctrl.Result{}, r.Status().Update(ctx, externalIP)
+		return ctrl.Result{RequeueAfter: time.Second * 5}, r.Status().Update(ctx, externalIP)
 	}
 
 	// 3rd STEP
@@ -180,7 +181,7 @@ func (r *ExternalIPReconciler) reconcileExternalIP(ctx context.Context, log logr
 			externalIP.Status.State = v1alpha1.ExternalIPStateAssociated
 			externalIP.Status.InstanceID = &instanceID
 			log.V(1).Info("Updating ExternalIP", "state", externalIP.Status.State, "InstanceID", externalIP.Status.InstanceID)
-			return ctrl.Result{}, r.Status().Update(ctx, externalIP)
+			return ctrl.Result{RequeueAfter: time.Second * 5}, r.Status().Update(ctx, externalIP)
 		}
 
 		// No spec.nodeName, no association, end reconciliation for ExternalIP.
@@ -288,7 +289,7 @@ func (r *ExternalIPReconciler) reconcileExternalIPDeletion(ctx context.Context, 
 		// set State to None for finalizer to delete externalIP object
 		externalIP.Status.State = v1alpha1.ExternalIPStateNone
 		log.V(1).Info("Updating ExternalIP", "state", externalIP.Status.State)
-		return ctrl.Result{}, r.Status().Update(ctx, externalIP)
+		return ctrl.Result{RequeueAfter: time.Second * 5}, r.Status().Update(ctx, externalIP)
 	}
 
 	// 3rd STEP

--- a/controllers/firewallrule_controller.go
+++ b/controllers/firewallrule_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -163,7 +164,7 @@ func (r *FirewallRuleReconciler) reconcileFirewallRule(ctx context.Context, log 
 		}
 		rule.Status.LastApplied = helper.StringPointerOrNil(string(lastApplied))
 		log.V(1).Info("Updating FirewallRule", "state", rule.Status.State, "firewallRuleID", rule.Status.FirewallRuleID)
-		return ctrl.Result{}, r.Status().Update(ctx, rule)
+		return ctrl.Result{RequeueAfter: time.Second * 5}, r.Status().Update(ctx, rule)
 	} else if rule.Spec.NodeName != nil {
 		lastApplied := &v1alpha1.FirewallRuleSpec{}
 		if err := json.Unmarshal([]byte(helper.StringValue(rule.Status.LastApplied)), lastApplied); err != nil {
@@ -204,7 +205,7 @@ func (r *FirewallRuleReconciler) reconcileFirewallRule(ctx context.Context, log 
 			}
 			rule.Status.LastApplied = helper.StringPointerOrNil(string(lastApplied))
 			log.V(1).Info("Updating FirewallRule", "state", rule.Status.State, "firewallRuleID", rule.Status.FirewallRuleID)
-			return ctrl.Result{}, r.Status().Update(ctx, rule)
+			return ctrl.Result{RequeueAfter: time.Second * 5}, r.Status().Update(ctx, rule)
 		}
 	}
 
@@ -265,7 +266,7 @@ func (r *FirewallRuleReconciler) reconcileFirewallRule(ctx context.Context, log 
 		rule.Status.InstanceID = &instanceID
 		rule.Status.NetworkInterfaceID = &networkInterface.NetworkInterfaceID
 		log.V(1).Info("Updating FirewallRule", "state", rule.Status.State, "instanceID", rule.Status.InstanceID, "networkInterfaceID", rule.Status.NetworkInterfaceID)
-		return ctrl.Result{}, r.Status().Update(ctx, rule)
+		return ctrl.Result{RequeueAfter: time.Second * 5}, r.Status().Update(ctx, rule)
 	}
 
 	// FirewallRule reliability check
@@ -409,7 +410,7 @@ func (r *FirewallRuleReconciler) clearFirewallRule(ctx context.Context, log logr
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
Add a delay between two reconciliation with Status Update for external IPs & Firewall Rules to prevent double.