### PR TITLE
Disable outbound firewall rules reconciliation

### DIFF
--- a/controllers/firewallrule_controller.go
+++ b/controllers/firewallrule_controller.go
@@ -76,6 +76,11 @@ func (r *FirewallRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	if firewallRule.Spec.Direction == v1alpha1.DirectionEgress {
+		log.Info("Egress Rule, do nothing")
+		return ctrl.Result{}, nil
+	}
+
 	if firewallRule.Spec.DisableReconciliation {
 		log.Info("Reconciliation disabled")
 		return ctrl.Result{}, nil


### PR DESCRIPTION
This is a quick fix because, outbound rules reconciliation is broken by conception, I will explain: 

- Node1 will have a rule on a srt caller to add outbound on port 1240 
- Node2 will have a rule on srt caller to add outbound on port 1240 

Kubestatic will try to create a rule with this port for node1 => Ok
Kubestatic will try to create a rule with this port for node2 =>  InvalidPermission.Duplicate: the specified rule \"peer: 0.0.0.0/0, UDP, from port: 1240, to port: 1240, ALLOW\" already exists\n\tstatus code: 400,

And the magic append here: 
https://github.com/quortex/kubestatic/blob/main/pkg/provider/aws/provider.go#L266-L278

At each reconciliation a new security group is created but the status of CR FirewallRule is not updated because an error occurs on rules creation. 

We don't need outbound rules on current AWS deployment because the VPC have access to all port on the outbound direction.