### PR TITLE
Fix FirewallRules concurency issues using a status known LastTransiti…

### DIFF
--- a/api/v1alpha1/firewallrule_types.go
+++ b/api/v1alpha1/firewallrule_types.go
@@ -94,7 +94,7 @@ type FirewallRuleStatus struct {
 	LastApplied *string `json:"lastApplied,omitempty"`
 
 	// lastTransitionTime is the last time the status transitioned from one status to another.
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Format=date-time
 	LastTransitionTime metav1.Time `json:"lastTransitionTime"`

--- a/api/v1alpha1/firewallrule_types.go
+++ b/api/v1alpha1/firewallrule_types.go
@@ -93,6 +93,12 @@ type FirewallRuleStatus struct {
 	// The latest FirewallRule specification applied, used to make API requests to cloud providers only if the resource has been changed to avoid throttling issues.
 	LastApplied *string `json:"lastApplied,omitempty"`
 
+	// lastTransitionTime is the last time the status transitioned from one status to another.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
+	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+
 	// The firewall rule identifier
 	FirewallRuleID *string `json:"firewallRuleID,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -231,6 +231,7 @@ func (in *FirewallRuleStatus) DeepCopyInto(out *FirewallRuleStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
 	if in.FirewallRuleID != nil {
 		in, out := &in.FirewallRuleID, &out.FirewallRuleID
 		*out = new(string)

--- a/config/crd/bases/kubestatic.quortex.io_firewallrules.yaml
+++ b/config/crd/bases/kubestatic.quortex.io_firewallrules.yaml
@@ -126,6 +126,11 @@ spec:
                   make API requests to cloud providers only if the resource has been
                   changed to avoid throttling issues.
                 type: string
+              lastTransitionTime:
+                description: lastTransitionTime is the last time the status transitioned
+                  from one status to another.
+                format: date-time
+                type: string
               networkInterfaceID:
                 description: The network interface identifier
                 type: string

--- a/config/crd/bases/kubestatic.quortex.io_firewallrules.yaml
+++ b/config/crd/bases/kubestatic.quortex.io_firewallrules.yaml
@@ -137,6 +137,8 @@ spec:
               state:
                 description: The current state of the FirewallRule
                 type: string
+            required:
+            - lastTransitionTime
             type: object
         type: object
     served: true

--- a/controllers/firewallrule_controller.go
+++ b/controllers/firewallrule_controller.go
@@ -472,8 +472,7 @@ func (r *FirewallRuleReconciler) clearFirewallRule(ctx context.Context, log logr
 	}
 
 	// Update status
-	rule.Status.LastTransitionTime = metav1.Now()
-	rule.Status = v1alpha1.FirewallRuleStatus{State: v1alpha1.FirewallRuleStateNone}
+	rule.Status = v1alpha1.FirewallRuleStatus{State: v1alpha1.FirewallRuleStateNone, LastTransitionTime: metav1.Now()}
 	log.V(1).Info("Updating FirewallRule", "state", rule.Status.State)
 	if err := r.Status().Update(ctx, rule); err != nil {
 		log.Error(err, "Failed to update FirewallRule state", "firewallRule", rule.Name)

--- a/helm/kubestatic/Chart.yaml
+++ b/helm/kubestatic/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.1
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.10.1
+appVersion: 0.11.0

--- a/helm/kubestatic/README.md
+++ b/helm/kubestatic/README.md
@@ -1,6 +1,6 @@
 # kubestatic
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 An operator to manage the lifecycle of public cloud providers resources needed to expose endpoints on public nodes.
 

--- a/helm/kubestatic/crds/crds.yaml
+++ b/helm/kubestatic/crds/crds.yaml
@@ -212,6 +212,8 @@ spec:
                 state:
                   description: The current state of the FirewallRule
                   type: string
+              required:
+                - lastTransitionTime
               type: object
           type: object
       served: true

--- a/helm/kubestatic/crds/crds.yaml
+++ b/helm/kubestatic/crds/crds.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: externalips.kubestatic.quortex.io
 spec:
   group: kubestatic.quortex.io
@@ -30,10 +29,19 @@ spec:
           description: ExternalIP is the Schema for the externalips API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -78,8 +86,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: firewallrules.kubestatic.quortex.io
 spec:
   group: kubestatic.quortex.io
@@ -106,10 +113,19 @@ spec:
           description: FirewallRule is the Schema for the firewallrules API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -130,7 +146,9 @@ spec:
                   description: Whether to disable reconciliation of this resource for development purpose
                   type: boolean
                 fromPort:
-                  description: The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type number.
+                  description: |-
+                    The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6
+                    type number.
                   format: int64
                   type: integer
                 ipRanges:
@@ -139,10 +157,14 @@ spec:
                     description: IPRange Describes an IPv4 range.
                     properties:
                       cidr:
-                        description: The IPv4 CIDR range. You can either specify a CIDR range or a source security group, not both. To specify a single IPv4 address, use the /32 prefix length.
+                        description: |-
+                          The IPv4 CIDR range. You can either specify a CIDR range or a source security
+                          group, not both. To specify a single IPv4 address, use the /32 prefix length.
                         type: string
                       description:
-                        description: A description for the rule that references this IPv4 address range.
+                        description: |-
+                          A description for the rule that references this IPv4 address
+                          range.
                         type: string
                     required:
                       - cidr
@@ -153,7 +175,10 @@ spec:
                   description: NodeName is the node's instance on which the firewall rule must be attached
                   type: string
                 protocol:
-                  description: The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)). Use -1 to specify all protocols.
+                  description: |-
+                    The IP protocol name (tcp, udp, icmp, icmpv6) or number (see Protocol Numbers
+                    (http://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)).
+                    Use -1 to specify all protocols.
                   type: string
                 toPort:
                   description: The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code.
@@ -176,6 +201,10 @@ spec:
                   type: string
                 lastApplied:
                   description: The latest FirewallRule specification applied, used to make API requests to cloud providers only if the resource has been changed to avoid throttling issues.
+                  type: string
+                lastTransitionTime:
+                  description: lastTransitionTime is the last time the status transitioned from one status to another.
+                  format: date-time
                   type: string
                 networkInterfaceID:
                   description: The network interface identifier

--- a/helm/kubestatic/templates/manager_role.yaml
+++ b/helm/kubestatic/templates/manager_role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: {{ include "kubestatic.fullname" . }}-manager-role
 rules:
   - apiGroups:


### PR DESCRIPTION
If a rule LastTransitionTime is before the one stored locally, the cache is not yet aware of a change we made. 
To avoid consistency issues, e.g. creating multiples groups for a single node, we requeue. 