### PR TITLE
Fix bug caused by controller-runtime caching

### DIFF
--- a/internal/controller/externalip_controller.go
+++ b/internal/controller/externalip_controller.go
@@ -75,6 +75,12 @@ func (r *ExternalIPReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	if !externalIP.ObjectMeta.DeletionTimestamp.IsZero() && len(externalIP.ObjectMeta.Finalizers) == 0 {
+		// Object is in process of being deleted and no finalizers left – likely going to disappear
+		log.Info("ExternalIP found with deletion timestamp and no finalizers. Ignoring since object must be deleted")
+		return ctrl.Result{}, nil
+	}
+
 	if externalIP.Spec.DisableReconciliation {
 		log.Info("Reconciliation disabled")
 		return ctrl.Result{}, nil

--- a/internal/controller/firewallrule_controller.go
+++ b/internal/controller/firewallrule_controller.go
@@ -78,6 +78,12 @@ func (r *FirewallRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
+	if !firewallRule.ObjectMeta.DeletionTimestamp.IsZero() && len(firewallRule.ObjectMeta.Finalizers) == 0 {
+		// Object is in process of being deleted and no finalizers left – likely going to disappear
+		log.Info("FirewallRule found with deletion timestamp and no finalizers. Ignoring since object must be deleted")
+		return ctrl.Result{}, nil
+	}
+
 	if firewallRule.Spec.DisableReconciliation {
 		log.Info("Reconciliation disabled")
 		return ctrl.Result{}, nil


### PR DESCRIPTION
Sometimes we would have race condition between kubernetes garbage collector and kubestatic resources where a deleted resource would be reconciled after the finalizer is removed