### PR TITLE
Fixes externalIP reconciliation issue when node is deleted

### DIFF
--- a/internal/controller/externalip_controller.go
+++ b/internal/controller/externalip_controller.go
@@ -104,9 +104,9 @@ func (r *ExternalIPReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			if apierrors.IsNotFound(err) {
 				// Invalid nodeName, remove ExternalIP nodeName attribute.
 				externalIP.Spec.NodeName = ""
-				if err != r.Update(ctx, externalIP) {
-					log.Error(err, "Failed to remove nodeName from ExternalIP spec", "nodeName", externalIP.Spec.NodeName)
-					return ctrl.Result{}, err
+				if removeNodeNameErr := r.Update(ctx, externalIP); removeNodeNameErr != nil {
+					log.Error(errors.Join(removeNodeNameErr, err), "Failed to remove nodename during error handling")
+					return ctrl.Result{}, fmt.Errorf("failed to remove nodename during error handling: %w", errors.Join(removeNodeNameErr, err))
 				}
 				log.Info("Node not found. Removing it from ExternalIP spec", "nodeName", externalIP.Spec.NodeName)
 				return ctrl.Result{}, nil

--- a/internal/provider/aws/converter/error_decoder.go
+++ b/internal/provider/aws/converter/error_decoder.go
@@ -67,6 +67,9 @@ func DecodeCommonError(msg string, err error) error {
 		case
 			"RulesPerSecurityGroupLimitExceeded":
 			return &provider.Error{Code: provider.RulesPerSecurityGroupLimitExceededError, Msg: msg}
+		case
+			"InvalidAssociationID.NotFound":
+			return &provider.Error{Code: provider.InvalidAssociationIDNotFound, Msg: msg}
 		}
 	}
 

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -23,6 +23,8 @@ const (
 	AddressLimitExceededError ErrorCode = "AddressLimitExceeded"
 	// InternalError is when there was an unexpected error in the server
 	InternalError ErrorCode = "InternalError"
+	// InvalidAssociationIDNotFound is when the association ID does not exist
+	InvalidAssociationIDNotFound ErrorCode = "InvalidAssociationIDNotFound"
 )
 
 // Error is the error type used internally by the backend
@@ -79,6 +81,14 @@ func IsErrInternal(err error) bool {
 func IsErrRulesPerSecurityGroupLimitExceeded(err error) bool {
 	if e, ok := err.(*Error); ok {
 		return e.Code == RulesPerSecurityGroupLimitExceededError
+	}
+	return false
+}
+
+// IsErrInvalidAssociationIDNotFound returns if error is kind InvalidAssociationIDNotFound
+func IsErrInvalidAssociationIDNotFound(err error) bool {
+	if e, ok := err.(*Error); ok {
+		return e.Code == InvalidAssociationIDNotFound
 	}
 	return false
 }


### PR DESCRIPTION
The reconciliation fails if the EIP is attached to a node and the node is deleted.
The association would be removed from AWS but still be cached in the addresses cache